### PR TITLE
Support for different tokenize functions

### DIFF
--- a/lib/naive_bayes.js
+++ b/lib/naive_bayes.js
@@ -65,7 +65,7 @@ function Naivebayes (options) {
 
   this.options = options
 
-  this.tokenize = tokenize || options.tokenizer;
+  this.tokenize = options.tokenizer || tokenize;
 
   //initialize our vocabulary and its size
   this.vocabulary = {}


### PR DESCRIPTION
The user can now provide a different tokenize function. Eg: tokenize and
remove stopwords

```
var normalize = function normalize(word) {
    return word.toLowerCase().replace(/['"”“\]\[<>#$%&’‘\+\*]/g,"").trim();
};

var stopWords = ["the"];

var tokenize = function (text) {
    words = text.split(/[\s\-_():.!\?,;\n]+/);

    return words.map(exports.normalize).filter(function(word) {
            return word.length > 2 && (!~stopWords.indexOf(word)) && !word.match(/\d/g);
        });
}

var classifier = bayes({tokenizer: tokenize})
```
