### PR TITLE
Implemented `toJsonObject` and allowed `fromJson` to accept JSON objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/node_modules/

--- a/lib/naive_bayes.js
+++ b/lib/naive_bayes.js
@@ -15,16 +15,21 @@ var STATE_KEYS = module.exports.STATE_KEYS = [
  * Initializes a NaiveBayes instance from a JSON state representation.
  * Use this with classifier.toJson().
  *
- * @param  {String} jsonStr   state representation obtained by classifier.toJson()
+ * @param  {String} jsonStr   state representation obtained by classifier.toJson() or classifier.toJsonObject()
  * @return {NaiveBayes}       Classifier
  */
 module.exports.fromJson = function (jsonStr) {
   var parsed;
-  try {
-    parsed = JSON.parse(jsonStr)
-  } catch (e) {
-    throw new Error('Naivebayes.fromJson expects a valid JSON string.')
+  if(typeof jsonStr === 'string') {
+    try {
+      parsed = JSON.parse(jsonStr)
+    } catch (e) {
+      throw new Error('Naivebayes.fromJson expects a valid JSON string.')
+    }
+  } else if(typeof jsonStr === 'object') {
+    parsed = jsonStr // if it's an object try use it directly
   }
+  
   // init a new classifier
   var classifier = new Naivebayes(parsed.options)
 
@@ -255,18 +260,25 @@ Naivebayes.prototype.frequencyTable = function (tokens) {
 }
 
 /**
- * Dump the classifier's state as a JSON string.
- * @return {String} Representation of the classifier.
+ * Dump the classifier's state as a simple object, suitable for embedding within a JSON document or another object.
+ * @return {Object} Representation of the classifier.
  */
-Naivebayes.prototype.toJson = function () {
+Naivebayes.prototype.toJsonObject = function () {
   var state = {}
   var self = this
   STATE_KEYS.forEach(function (k) {
     state[k] = self[k]
   })
+  
+  return state
+}
 
-  var jsonStr = JSON.stringify(state)
-
+/**
+ * Dump the classifier's state as a JSON string.
+ * @return {String} Representation of the classifier.
+ */
+Naivebayes.prototype.toJson = function () {
+  var jsonStr = JSON.stringify(this.toJsonObject())
   return jsonStr
 }
 

--- a/readme.md
+++ b/readme.md
@@ -72,11 +72,15 @@ Returns the `category` it thinks `text` belongs to. Its judgement is based on wh
 
 ###`classifier.toJson()`
 
-Returns the JSON representation of a classifier.
+Returns the JSON representation of a classifier. This is the same as `JSON.stringify(classifier.toJsonObject())`.
+
+###`classifier.toJsonObject()`
+
+Returns a JSON-friendly representation of the classifier as an `object`.
 
 ###`var classifier = bayes.fromJson(jsonStr)`
 
-Returns a classifier instance from the JSON representation. Use this with the JSON representation obtained from `classifier.toJson()`
+Returns a classifier instance from the JSON representation. Use this with the JSON representation obtained from `classifier.toJson()` or `classifier.toJsonObject()`
 
 ## License
 

--- a/test/naive_bayes.js
+++ b/test/naive_bayes.js
@@ -74,6 +74,24 @@ describe('bayes serializing/deserializing its state', function () {
 
       done()
     })
+    
+  it('serializes/deserializes its state as an Object correctly.', function (done) {
+      var classifier = bayes()
+
+      classifier.learn('Fun times were had by all', 'positive')
+      classifier.learn('sad dark rainy day in the cave', 'negative')
+
+      var jsonRepr = classifier.toJsonObject()
+
+      var revivedClassifier = bayes.fromJson(jsonRepr)
+
+      // ensure the revived classifier's state is same as original state
+      bayes.STATE_KEYS.forEach(function (k) {
+        assert.deepEqual(revivedClassifier[k], classifier[k])
+      })
+
+      done()
+    })
 })
 
 describe('bayes .learn() correctness', function () {


### PR DESCRIPTION
This will allow bayes classifiers to be serialised / de-serialised as part of larger JSON models (or even as MongoDB documents)