### PR TITLE
Optionally pretty print the serialized JSON output

### DIFF
--- a/lib/naive_bayes.js
+++ b/lib/naive_bayes.js
@@ -256,16 +256,18 @@ Naivebayes.prototype.frequencyTable = function (tokens) {
 
 /**
  * Dump the classifier's state as a JSON string.
+ * @param {Boolean} Optionally format the serialized JSON output for easier human consumption
  * @return {String} Representation of the classifier.
  */
-Naivebayes.prototype.toJson = function () {
+Naivebayes.prototype.toJson = function (prettyPrint) {
   var state = {}
   var self = this
+  var prettyPrintSpaces = prettyPrint ? 2 : 0
   STATE_KEYS.forEach(function (k) {
     state[k] = self[k]
   })
 
-  var jsonStr = JSON.stringify(state)
+  var jsonStr = JSON.stringify(state, null, prettyPrintSpaces)
 
   return jsonStr
 }


### PR DESCRIPTION
When wanting to manually analyze the state of the classifier, it's easier if the serialized JSON dump is pretty printed.