### PR TITLE
Use Object.create(null) instead of {}

### DIFF
--- a/lib/naive_bayes.js
+++ b/lib/naive_bayes.js
@@ -77,7 +77,7 @@ function Naivebayes (options) {
   this.tokenizer = this.options.tokenizer || defaultTokenizer
 
   //initialize our vocabulary and its size
-  this.vocabulary = {}
+  this.vocabulary = Object.create(null);
   this.vocabularySize = 0
 
   //number of documents we have learned from
@@ -85,17 +85,17 @@ function Naivebayes (options) {
 
   //document frequency table for each of our categories
   //=> for each category, how often were documents mapped to it
-  this.docCount = {}
+  this.docCount = Object.create(null);
 
   //for each category, how many words total were mapped to it
-  this.wordCount = {}
+  this.wordCount = Object.create(null);
 
   //word frequency table for each category
   //=> for each category, how frequent was a given word mapped to it
-  this.wordFrequencyCount = {}
+  this.wordFrequencyCount = Object.create(null);
 
   //hashmap of our category names
-  this.categories = {}
+  this.categories = Object.create(null);
 }
 
 /**
@@ -107,7 +107,7 @@ Naivebayes.prototype.initializeCategory = function (categoryName) {
   if (!this.categories[categoryName]) {
     this.docCount[categoryName] = 0
     this.wordCount[categoryName] = 0
-    this.wordFrequencyCount[categoryName] = {}
+    this.wordFrequencyCount[categoryName] = Object.create(null);
     this.categories[categoryName] = true
   }
   return this


### PR DESCRIPTION
Otherwise you cannot index documents with the word "constructor" or create categories with that name. Fixes #14.

