### PR TITLE
Add support for de-serializing an empty classifier

### DIFF
--- a/lib/naive_bayes.js
+++ b/lib/naive_bayes.js
@@ -30,7 +30,7 @@ module.exports.fromJson = function (jsonStr) {
 
   // override the classifier's state
   STATE_KEYS.forEach(function (k) {
-    if (!parsed[k]) {
+    if (typeof parsed[k] === 'undefined' || parsed[k] === null) {
       throw new Error('Naivebayes.fromJson: JSON string is missing an expected property: `'+k+'`.')
     }
     classifier[k] = parsed[k]

--- a/test/naive_bayes.js
+++ b/test/naive_bayes.js
@@ -74,6 +74,30 @@ describe('bayes serializing/deserializing its state', function () {
 
       done()
     })
+
+  it('allows de-serializing an empty state', function (done) {
+    var classifier = bayes();
+    var jsonRepr = classifier.toJson()
+    bayes.fromJson(jsonRepr);
+    done();
+  });
+
+  it('fails on an missing fields', function (done) {
+    var classifier = bayes();
+    var jsonRepr = classifier.toJson();
+
+    jsonRepr = JSON.parse(jsonRepr);
+    delete jsonRepr.totalDocuments;
+    jsonRepr = JSON.stringify(jsonRepr);
+
+    try {
+      bayes.fromJson(jsonRepr);
+    } catch (e) {
+      return done();
+    }
+
+    done(new Error('should have thrown'));
+  })
 })
 
 describe('bayes .learn() correctness', function () {


### PR DESCRIPTION
This PR changes the `fromJson` function to allow zeros and empty strings when de-serializing a saved classifier and only fails on missing values (`undefined` or `null`).